### PR TITLE
Add option to measure throughput only in time frame where all Jobs are running

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -125,6 +125,18 @@ if __name__ == "__main__":
                      help = 'do not allow HyperThreading/Simultaneous multithreading (used only if cpu_affinity = True)')
 
   group = parser.add_mutually_exclusive_group()
+  group.add_argument('--overlap-only',
+                     dest = 'overlap',
+                     action = 'store_true',
+                     default = False,
+                     help = 'Consider only time frame where all the jobs are running [default: False]')
+  group.add_argument('--no-overlap-only',
+                     dest = 'overlap',
+                     action = 'store_true',
+                     default = True,
+                     help = 'Do not consider only time frame where all the jobs are running [default: True]')
+
+  group = parser.add_mutually_exclusive_group()
   group.add_argument('-n', '--numa-affinity',
                      dest = 'numa_affinity',
                      action = 'store_true',
@@ -198,6 +210,7 @@ if __name__ == "__main__":
     'streams'             : opts.streams,
     'gpus_per_job'        : opts.gpus_per_job,
     'allow_hyperthreading': opts.allow_hyperthreading,
+    'overlap_only'        : opts.overlap,
     'set_numa_affinity'   : opts.numa_affinity,
     'set_cpu_affinity'    : opts.cpu_affinity,
     'set_gpu_affinity'    : opts.gpu_affinity,


### PR DESCRIPTION
This PR is meant to add the option `--overlap-only` to measure the throughput only on the events where all the jobs are running (overlap == 1).
It also add the `start` and `end` time for each repetition (for the time frame considered) in the output. This is needed to allow us to  to match the time in which the process is running with a separate measure of the power consumption.

Example:
Running on 5300 events. First 300 are skipped by default, final processed events are 4600, meaning that it didn't consider 200 events per job (in this case they would probably be the first and last bunch of 100 events)
```
[wredjeb@gputest-bergamo-01 src]$ ./patatrack-scripts/benchmark hltMenu.py -r 1 -j 2 -t 8 -s 8 -k resources.json --logdir logCPU512 -e 5300 --no-warmup --overlap-only
2 CPUs:
  0: AMD EPYC 9754 128-Core Processor (128 cores, 256 threads)
  1: AMD EPYC 9754 128-Core Processor (128 cores, 256 threads)

4 visible NVIDIA GPUs:
  0: NVIDIA L4
  1: NVIDIA L4
  2: NVIDIA L4
  3: NVIDIA L4

Benchmarking hltMenu.py
Running once over 5300 events with 2 jobs, each with 8 threads, 8 streams and 1 GPUs
        Start   08/12/24 12:25:10.177
        End     08/12/24 12:27:07.934
    76.1 _   0.1 ev/s (4600 events, 100.0% overlap)
```