### PR TITLE
Add options to configure the throughput measurements

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -23,6 +23,8 @@ if __name__ == "__main__":
     'plumbing'            : opts.plumbing,
     'warmup'              : opts.warmup,
     'events'              : opts.events,
+    'resolution'          : opts.event_resolution,
+    'skipevents'          : opts.event_skip,
     'repeats'             : opts.repeats,
     'jobs'                : opts.jobs,
     'threads'             : opts.threads,

--- a/multirun.py
+++ b/multirun.py
@@ -38,9 +38,6 @@ gpus = get_gpu_info()
 
 epoch = datetime.now()
 
-# skip at least this many events at the beginning of a job when measuring the throughput
-skipevents = 300
-
 def is_iterable(item):
   try:
     iter(item)
@@ -212,6 +209,8 @@ def multiCmsRun(
     verbose = False,                # whether to print extra messages
     plumbing = False,               # print output in a machine-readable format
     events = -1,                    # number of events to process (default: unlimited)
+    resolution = 100,               # sample the number of processed events with the given resolution (default: 100)
+    skipevents = 300,               # skip the firts EVENTS in each job, rounded to the next multiple of the event resulution (default: 300)
     repeats = 1,                    # number of times to repeat each job (default: 1)
     jobs = 1,                       # number of jobs to run in parallel (default: 1)
     threads = 1,                    # number of CPU threads per job (default: 1)
@@ -232,13 +231,13 @@ def multiCmsRun(
   # set the number of events to process
   process.maxEvents.input = cms.untracked.int32( events )
 
-  # print a message every 100 events
+  # print a message every "resolution" events
   if not 'ThroughputService' in process.__dict__:
     process.ThroughputService = cms.Service('ThroughputService',
       enableDQM = cms.untracked.bool(False),
     )
   process.ThroughputService.printEventSummary = cms.untracked.bool(True)
-  process.ThroughputService.eventResolution = cms.untracked.uint32(100)
+  process.ThroughputService.eventResolution = cms.untracked.uint32(resolution)
   if events > -1:
     process.ThroughputService.eventRange = cms.untracked.uint32(events)
 

--- a/options.py
+++ b/options.py
@@ -60,6 +60,20 @@ If an empty list is used, all GPUs are disabled and no GPUs are used by the job.
             type = int,
             default = 10300,
             help = 'number of events per cmsRun job [default: 10300]')
+        self.parser.add_argument('--event-resolution',
+            dest = 'event_resolution',
+            metavar = 'EVENTS',
+            action = 'store',
+            type = int,
+            default = 100,
+            help = 'sample the number of processed events with the given resolution')
+        self.parser.add_argument('--event-skip',
+            dest = 'event_skip',
+            metavar = 'EVENTS',
+            action = 'store',
+            type = int,
+            default = 300,
+            help = 'skip the firts EVENTS in each job, rounded to the next multiple of the event resulution')
 
         self.parser.add_argument('-j', '--jobs',
             dest = 'jobs',

--- a/scan
+++ b/scan
@@ -89,6 +89,8 @@ if __name__ == "__main__":
     'plumbing'            : opts.plumbing,
     'warmup'              : opts.warmup,
     'events'              : opts.events,
+    'resolution'          : opts.event_resolution,
+    'skipevents'          : opts.event_skip,
     'repeats'             : opts.repeats,
     'jobs'                : opts.jobs,
     'threads'             : opts.threads,


### PR DESCRIPTION
Add options to configure the granularity of the measurements, and how many events to skip at the beginning of each job.