### PR TITLE
Let each slot run on a different number of events

### DIFF
--- a/multirun.py
+++ b/multirun.py
@@ -42,6 +42,20 @@ def singleCmsRun(filename, workdir, executable = 'cmsRun', logdir = None, keep =
   if slot is None:
       slot = Slot()
 
+  # if the slot requires a custom number of events, create a copy of the input file and update it accordingly
+  if slot.events is not None:
+    # create a new configuration file
+    oldfilename = filename
+    filename = workdir + '/process.py'
+    with open(oldfilename, 'r') as oldfile, open(filename, 'w') as newfile:
+      # copy the original content to the new configuration file
+      oldfile.seek(0)
+      newfile.write(oldfile.read())
+      # update the number of events in the temporary file
+      newfile.write(f'\n# update the number of events to process\nprocess.maxEvents.input = cms.untracked.int32({slot.events})\n')
+      if slot.events > -1:
+        newfile.write(f'process.ThroughputService.eventRange = cms.untracked.uint32({slot.events})\n')
+
   # command to execute
   command = [ executable, filename ] + list(args)
   # shell environment

--- a/options.py
+++ b/options.py
@@ -17,6 +17,7 @@ This options disables the automatic job assignment to CPUs and GPUs, and makes t
 Each '--slot' option describes the execution environment for a single job. If theare more jobs (see the --jobs option) than slots, they are reused in a round-robin fashion until all jobs are allocated.
 The format of SLOT is a colon-separated list of fields, where each field has the format 'keyword=value'.
 The possible fields, their formats and descriptions are:
+   [events|e]=EVENTS        where EVENTS is a positive integer, or -1 to run over all events in the input dataset, and overrides the --events options for this slot;
    [numa|n]=NODES           where NODES indicates the NUMA nodes of the CPUs to be used by the job;
    [mem|m]=NODES            where NODES indicates the NUMA nodes of the memory to be used by the job;
    [cpu|c]=CPUS             where CPUS indicates the individual CPUs to be used by the job;


### PR DESCRIPTION
Relax the requirement that all jobs process the same number of events, and let each slot run on a different number of events.