### PR TITLE
Inserted example in -h help message for the --keep arg.

### DIFF
--- a/multirun.py
+++ b/multirun.py
@@ -288,6 +288,11 @@ def singleCmsRun(filename, workdir, logdir = None, keep = [], autodelete = [], a
       continue
 
     matches = line_pattern.match(line)
+    # Warning if the number of events used is too low
+    if "Not enough events to measure the throughput" in line:
+      strippedLine = line.strip().replace('\n', '')
+      print(f"Warning: {strippedLine}")
+    
     # check for the end of the events list
     if not matches:
       break

--- a/options.py
+++ b/options.py
@@ -74,7 +74,7 @@ If an empty list is used, all GPUs are disabled and no GPUs are used by the job.
             action = 'store',
             type = int,
             default = 300,
-            help = 'skip the firts EVENTS in each job, rounded to the next multiple of the event resulution')
+            help = 'skip the firts EVENTS in each job, rounded to the next multiple of the event resulution [default: 300]')
 
         self.parser.add_argument('-j', '--jobs',
             dest = 'jobs',

--- a/options.py
+++ b/options.py
@@ -233,10 +233,12 @@ If an empty list is used, all GPUs are disabled and no GPUs are used by the job.
             help = 'do not store log files (equivalent to "--logdir \'\'")')
 
         self.parser.add_argument('-k', '--keep',
-            dest = 'keep',
-            nargs = '+',
-            default = ['resources.json'],
-            help = 'list of additional output files to be kept in logdir, along with the logs [default: "resources.json"]')
+            dest='keep',
+            nargs='+',
+            default=['resources.json'],
+            metavar='FILE',
+            help= 'list of additional output files to be kept in logdir, along with the logs [default: "resources.json"]. For example, the argument "-k resources.json DQM.root --" keeps resources.json and DQM.root. Note: the dashes "--" avoid the parser to consume unintended arguments afterwards.'
+        )
 
         group = self.parser.add_mutually_exclusive_group()
         group.add_argument('--auto-merge',


### PR DESCRIPTION
The `-k` argument is used to keep additional outputs in the logdir.

If more than one file is included after the `-k` argument (like `-k file1 file2`) then double dashes shall be used in order to tell the parser the list of arguments pertaining to the keep parameter stops.

Many users (even experienced ones) are unaware of the need to use `--` in certain argparse cases. The proposed change introduces an example in the parameter description, effectively showing how to use the `-k` argument with more that one item.