### PR TITLE
Integrate benchmark plotting script

### DIFF
--- a/plot.py
+++ b/plot.py
@@ -25,6 +25,8 @@ parser.add_argument('-t', '--title', type=str, default="",
                     help="Title of the legend")
 parser.add_argument('-o', '--output', type=str, default="throughput_vs_threads",
                     help="Base filename for output files (PNG/PDF)")
+parser.add_argument('-x', '--x-axis', default='CPU threads per job',
+                    help='Horizontal axis label.')
 parser.add_argument('--csv_labels', nargs='+', default=None, required=False,
                     help="CSV labels to process (one-to-one mapping with the CSV files)")
 
@@ -78,7 +80,7 @@ for label, df in datasets.items():
                 label=label, marker='o', markersize=8, capsize=5, capthick=2,
                 ls='none', color=color)
 
-ax.set_xlabel("CPU threads per job")
+ax.set_xlabel(args.x_axis)
 ax.set_ylabel("Average throughput (ev/s)")
 ax.set_title("Average throughput vs number of CPU threads per job")
 if title:

--- a/plot.py
+++ b/plot.py
@@ -1,0 +1,92 @@
+#! /usr/bin/env python3
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from matplotlib.ticker import MultipleLocator
+import sys
+import os
+import argparse
+
+# Create the parser
+parser = argparse.ArgumentParser(description="Plot average throughput vs number of CPU threads per job")
+
+# Optional arguments
+parser.add_argument('-t', '--title', type=str, default="",
+                    help="Title of the legend")
+parser.add_argument('-o', '--output', type=str, default="throughput_vs_threads",
+                    help="Base filename for output files (PNG/PDF)")
+parser.add_argument('--csv_labels', nargs='+', default=None, required=False, help="CSV labels to process (one-to-one mapping with the CSV files)")
+
+# Positional arguments (CSV files)
+parser.add_argument('csv_files', nargs='+', help="CSV files to process")
+
+# Parse arguments
+args = parser.parse_args()
+
+# Access the values
+title = args.title
+filename = args.output
+csv_files = args.csv_files
+csv_labels = args.csv_labels
+if csv_labels is not None:
+    assert len(csv_files) == len(csv_labels)
+
+# Dictionary to store per-file datasets
+datasets = {}
+
+for file in csv_files:
+    # Read CSV and clean column names
+    df = pd.read_csv(file)
+    df.columns = df.columns.str.strip()
+    
+    # Keep only relevant columns (ignore "jobs")
+    df = df[["CPU threads per job", "average throughput (ev/s)"]]
+    
+    # Group by CPU threads per job and compute mean & std
+    grouped = (
+        df.groupby("CPU threads per job")["average throughput (ev/s)"]
+        .agg(['mean', 'std'])
+        .reset_index()
+        .sort_values("CPU threads per job")
+    )
+    
+    # Create a nicer label: remove extension and replace underscores
+    label = os.path.basename(file) if csv_labels is None else csv_labels[csv_files.index(file)]
+    if label.endswith(".csv"):
+        label = label[:-4]
+    label = label.replace("_", " ")
+    
+    datasets[label] = grouped
+
+# Plotting
+fig, ax = plt.subplots(figsize=(10, 6))
+for label, df in datasets.items():
+    #df["std"] = df["std"].fillna(0)  # In case some groups have a single entry
+    ax.errorbar(df["CPU threads per job"], df["mean"], yerr=df["std"],
+                label=label, marker='o', capsize=5, ecolor='black')
+
+ax.set_xlabel("CPU threads per job")
+ax.set_ylabel("Average throughput (ev/s)")
+ax.set_title("Average throughput vs number of CPU threads per job")
+if title:
+  ax.legend(title=title, title_fontsize='13', fontsize='11')
+else:
+  ax.legend()
+ax.grid(True, axis='x')
+ax.xaxis.set_major_locator(MultipleLocator(4))
+ax.grid(True, which='major', axis='x')
+ax.grid(True, which='major', axis='y')
+ax.set_ylim(bottom=0)
+
+# Make the axes (plot area) white
+ax.set_facecolor('white')
+
+# Make only the figure background (outside axes) transparent
+fig.patch.set_facecolor('none')  # fully transparent
+fig.patch.set_alpha(0)
+
+fig.tight_layout()
+
+# Save as PNG and PDF with transparent canvas background
+fig.savefig(f"{filename}.png", dpi=600)
+fig.savefig(f"{filename}.pdf")

--- a/plot.py
+++ b/plot.py
@@ -1,5 +1,14 @@
 #! /usr/bin/env python3
 
+"""
+Plot average throughput vs number of CPU threads per job.
+
+Command examples:
+
++ Read 3 csv files and store OUTPUT.pdf and OUTPUT.png:
+python3 patatrack-scipts/plot.py scan/reduced_hlt_{ecal,hcal,pixel}_w7900.csv --title Labels --csv_labels ECAL HCAL Pixel -o OUTPUT
+"""
+
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MultipleLocator
@@ -8,14 +17,15 @@ import os
 import argparse
 
 # Create the parser
-parser = argparse.ArgumentParser(description="Plot average throughput vs number of CPU threads per job")
+parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
 
 # Optional arguments
 parser.add_argument('-t', '--title', type=str, default="",
                     help="Title of the legend")
 parser.add_argument('-o', '--output', type=str, default="throughput_vs_threads",
                     help="Base filename for output files (PNG/PDF)")
-parser.add_argument('--csv_labels', nargs='+', default=None, required=False, help="CSV labels to process (one-to-one mapping with the CSV files)")
+parser.add_argument('--csv_labels', nargs='+', default=None, required=False,
+                    help="CSV labels to process (one-to-one mapping with the CSV files)")
 
 # Positional arguments (CSV files)
 parser.add_argument('csv_files', nargs='+', help="CSV files to process")

--- a/plot.py
+++ b/plot.py
@@ -85,10 +85,11 @@ if title:
   ax.legend(title=title, title_fontsize='13', fontsize='11')
 else:
   ax.legend()
-ax.grid(True, axis='x')
+
+transparency = dict(alpha=0.7)
+ax.grid(True, axis='x', **transparency)
 ax.xaxis.set_major_locator(MultipleLocator(4))
-ax.grid(True, which='major', axis='x')
-ax.grid(True, which='major', axis='y')
+ax.grid(True, which='major', axis='both', **transparency)
 ax.set_ylim(bottom=0)
 
 # Make the axes (plot area) white

--- a/plot.py
+++ b/plot.py
@@ -11,6 +11,7 @@ python3 patatrack-scipts/plot.py scan/reduced_hlt_{ecal,hcal,pixel}_w7900.csv --
 
 import pandas as pd
 import matplotlib.pyplot as plt
+plt.style.use('tableau-colorblind10')
 from matplotlib.ticker import MultipleLocator
 import sys
 import os
@@ -72,8 +73,10 @@ for file in csv_files:
 fig, ax = plt.subplots(figsize=(10, 6))
 for label, df in datasets.items():
     #df["std"] = df["std"].fillna(0)  # In case some groups have a single entry
+    color = ax.plot(df["CPU threads per job"], df["mean"], '--', linewidth=1.5)[0].get_color()
     ax.errorbar(df["CPU threads per job"], df["mean"], yerr=df["std"],
-                label=label, marker='o', capsize=5, ecolor='black')
+                label=label, marker='o', markersize=8, capsize=5, capthick=2,
+                ls='none', color=color)
 
 ax.set_xlabel("CPU threads per job")
 ax.set_ylabel("Average throughput (ev/s)")


### PR DESCRIPTION
This PR brings a plotting script to be used for all benchmark scans.

-------------

The plot below is obtained running

```bash
python3 /shared/patatrack-scripts/plot_scan.py scan/reduced_hlt_{ecal,hcal,pixel}_w7900.csv --title Labels -o OUTPUT --csv_labels ECAL HCAL Pixel
```

<img width="1053" height="627" alt="image" src="https://github.com/user-attachments/assets/06d6bad7-97b2-46c4-984f-e2fc57555716" />

where the input csv files were obtained with the ```patatrack-scripts/benchmarl``` tool.

For comparison, the current ```scan_plot.py``` utility was tested over the same input files, and the command below lead to a similar result:

```bash
python3 /shared/patatrack-scripts/plot_scan.py scan/reduced_hlt_{ecal,hcal,pixel}_w7900.csv -o OUTPLOT.pdf -x "CPU threads per job"
```

<img width="1053" height="463" alt="Screenshot From 2025-10-03 15-49-08" src="https://github.com/user-attachments/assets/bddfbb5f-63d8-4d1d-8834-e66cf98e1e20" />

Using the same older script with ```sns.lmplot.fit_reg = False``` lead to:

<img width="1053" height="463" alt="image" src="https://github.com/user-attachments/assets/cdd04533-3001-4e75-9470-bd808be57045" />

