### PR TITLE
Print options when verbose is True.

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -5,7 +5,7 @@ import os
 import copy
 import subprocess
 
-from options import OptionParser
+from options import OptionParser, printCommonArgs
 from multirun import *
 from slot import Slot
 import FWCore.ParameterSet.Config as cms
@@ -74,11 +74,7 @@ if __name__ == "__main__":
 
   # print configuration
   if opts.verbose:
-    print('Common options for multiCmsRun:')
-    for key, value in options.items():
-      print(f'  --{key}: {value}')
-    sys.stdout.flush()
-    print()
+    printCommonArgs(options)
     
   if opts.run_io_benchmark:
     # prepare a trimmed down configuration for benchmarking only reading the input data

--- a/multirun.py
+++ b/multirun.py
@@ -356,7 +356,7 @@ def multiCmsRun(
     set_numa_affinity = False,      # FIXME - run each job in a single NUMA node
     set_cpu_affinity = False,       # whether to set CPU affinity
     set_gpu_affinity = False,       # whether to set GPU affinity
-    slots = [],                     # explit job execution environment
+    slots = [],                     # explicit job execution environment
     automerge = True,               # automatically merge supported output across all jobs
     autodelete = [],                # automatically delete files matching the given patterns while running the jobs (default: do not autodelete)
     autodelete_delay = 60.,         # check for files to autodelete with this interval (default: 60s)

--- a/options.py
+++ b/options.py
@@ -1,5 +1,18 @@
+import sys
 import argparse
 from slot import Slot
+
+def printCommonArgs(opts):
+    print('Common options for multiCmsRun:')
+    for key, value in opts.items():
+        if key == 'slots':
+            print(f'  --{key}')
+            for idx, val in enumerate(value):
+                print(f'      slot {idx}: ' + ', '.join([f'{k}={v}' for x in value for k,v in vars(x).items()]))
+        else:
+            print(f'  --{key}: {value}')
+    print()
+    sys.stdout.flush()
 
 class OptionParser:
 

--- a/scan
+++ b/scan
@@ -175,12 +175,8 @@ if __name__ == "__main__":
 
     # print configuration
     if opts.verbose:
-      print('Common step options for multiCmsRun:')
-      for key, value in step_opt.items():
-        print(f'  --{key}: {value}')
-      sys.stdout.flush()
-      print()
-
+      printCommonArgs(step_opt)
+      
     # benchmark reading the input data
     if opts.run_io_benchmark:
       print('Benchmarking only I/O')


### PR DESCRIPTION
Print ```multiCmsRun``` options when ```opts.verbose``` is ```True```. This helps debugging during ```benchmark``` or ```scan``` runs.
The output looks as follows:

```bash
bfontana@sess-mi300x:/shared/CMSSW_15_1_X_2025-10-05-0000/run  $ ./patatrack-scripts/benchmark reduced_hlt_hcal.py -v -e 1000 --event-resolu
tion 10 --event-skip 300 -r 4 --wait 10 -j 1 -t 8 -s 0 --slot cpus=1-32:amd=0 -j 2                                                          
2 CPUs:                                                                                                                                     
  0: AMD EPYC 9534 64-Core Processor (64 cores, 128 threads)                                                                                
  1: AMD EPYC 9534 64-Core Processor (64 cores, 128 threads)                                                                                
                                                                                                                                            
No visible NVIDIA CUDA GPUs                                                                                                                 
                                                                                                                                            
1 visible AMD ROCm GPUs:                                                                                                                    
  0: AMD Instinct MI300X                                                                                                                    
                                                                                                                                            
Common options for multiCmsRun:                                                                                                             
  --verbose: True                                                                                                                           
  --plumbing: False                                                                                                                         
  --warmup: True                                                                                                                            
  --events: 1000                                                                                                                            
  --resolution: 10                                                                                                                          
  --skipevents: 300                                                                                                                         
  --repeats: 4                                                                                                                              
  --wait: 10.0                                                                                                                              
  --jobs: 2                                                                                                                                 
  --threads: 8                                                                                                                              
  --streams: 0                                                                                                                              
  --gpus_per_job: 1                                                                                                                         
  --allow_hyperthreading: True                                                                                                              
  --set_numa_affinity: False                                                                                                                
  --set_cpu_affinity: False                                                                                                                 
  --set_gpu_affinity: False                                                                                                                 
  --slots                                                                                                                                   
      slot 0: events=None, numa_cpu=None, numa_mem=None, cpus=None, nvidia_gpus=None, amd_gpus=['0']                                        
  --executable: cmsRun                                                                                                                      
  --data: None                                                                                                                              
  --header: True                                                                                                                            
  --logdir: logs                                                                                                                            
  --tmpdir: None                                                                                                                            
  --keep: ['resources.json']                                                                                                                
  --automerge: True                                                                                                                         
  --autodelete: []                                                                                                                          
  --autodelete_delay: 60.0                                                                                                                  
                                                                                                                                            
Benchmarking only I/O                                                                                                                       
Warming up                            
```