### PR TITLE
Ensure streams == threads whens treams are not specified.

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     options['jobs'] = count // options['threads']
 
   # the number of streams defaults to the number of threads per job
-  if options['streams'] is None:
+  if options['streams'] is None or options['streams'] == 0:
     options['streams'] = options['threads']
 
   process = parseProcess(opts.config)

--- a/scan
+++ b/scan
@@ -155,7 +155,7 @@ if __name__ == "__main__":
   for step in steps:
     # update the options for each step
     step_opt['threads'] = options['threads'] if options['threads'] is not None else step
-    step_opt['streams'] = options['streams'] if options['streams'] is not None else step
+    step_opt['streams'] = options['streams'] if options['streams'] is not None and options['streams'] != 0 else step
     step_opt['jobs']    = options['jobs']    if options['jobs']    is not None else (count + step - 1) // step
 
     # if the logs are enabled, use a separate directory for each step


### PR DESCRIPTION
Explicitly set the number of streams to be the same as the number of threads whenever the user sets the number of streams to zero.
This PR aims for clarity only, as CMSSW should enforce this behavior under the hood.