### PR TITLE
Rework the input-only benchmark

### DIFF
--- a/benchmark
+++ b/benchmark
@@ -82,18 +82,20 @@ if __name__ == "__main__":
   if opts.verbose:
     printCommonArgs(options)
     
-  if opts.run_io_benchmark:
+  if opts.input_benchmark:
     # prepare a trimmed down configuration for benchmarking only reading the input data
     io_process = copy.deepcopy(process)
-    io_process.hltGetRaw = cms.EDAnalyzer("HLTGetRaw", RawDataCollection = cms.InputTag("rawDataCollector"))
-    io_process.path = cms.Path(io_process.hltGetRaw)
+    io_process.prefetch = cms.EDAnalyzer("GenericConsumer",
+        eventProducts = cms.untracked.vstring(opts.input_collections.split(','))
+    )
+    io_process.path = cms.Path(io_process.prefetch)
     io_process.schedule = cms.Schedule(io_process.path)
     if 'PrescaleService' in io_process.__dict__:
       del io_process.PrescaleService
 
     # benchmark reading the input data
-    print('Benchmarking only I/O')
-    io_options = dict(options, logdir = None, keep = [], data = None)
+    print('Benchmarking only the input')
+    io_options = dict(options, repeats = opts.input_benchmark, logdir = None, keep = [], data = None)
     multiCmsRun(io_process, **io_options)
     print()
     # wait the required number of seconds between the I/O benchmark and the actual measurement

--- a/benchmark
+++ b/benchmark
@@ -14,6 +14,7 @@ if not 'CMSSW_BASE' in os.environ:
 import FWCore.ParameterSet.Config as cms
 
 # local packages
+from common import *
 from options import OptionParser, printCommonArgs
 from multirun import *
 from slot import Slot
@@ -83,10 +84,16 @@ if __name__ == "__main__":
     printCommonArgs(options)
     
   if opts.input_benchmark:
+    collections = opts.input_collections.split(',')
+
+    # read the list of input collections from the ReadBranches of a framework job report
+    if opts.input_xml:
+        collections = get_read_branch_names(opts.input_xml)
+
     # prepare a trimmed down configuration for benchmarking only reading the input data
     io_process = copy.deepcopy(process)
     io_process.prefetch = cms.EDAnalyzer("GenericConsumer",
-        eventProducts = cms.untracked.vstring(opts.input_collections.split(','))
+        eventProducts = cms.untracked.vstring(collections)
     )
     io_process.path = cms.Path(io_process.prefetch)
     io_process.schedule = cms.Schedule(io_process.path)

--- a/common.py
+++ b/common.py
@@ -1,0 +1,36 @@
+#! /usr/bin/env python3
+
+def get_read_branch_names(xml_path):
+    """
+    Open a framework job report XML file and return the list of branch names
+    that have bean read from the input files.
+
+    If the ReadBranches element looks like
+
+        <ReadBranches>
+        <Branch Name="FEDRawDataCollection_rawDataCollector__LHC." ReadCount="2926"/>
+        </ReadBranches>
+
+    this function would return [ 'FEDRawDataCollection_rawDataCollector__LHC' ].
+
+    """
+    import xml.etree.ElementTree as ET
+
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    read_branches = root.find("ReadBranches")
+    if read_branches is None:
+        return []
+
+    branch_names = []
+    for branch in read_branches.findall("Branch"):
+        name = branch.get("Name")
+        if name:
+            branch_names.append(name.rstrip("."))  # remove trailing dot(s)
+
+    return branch_names
+
+
+if __name__ == "__main__":
+    print('\n'.join(get_read_branch_names('test/report.xml')))

--- a/options.py
+++ b/options.py
@@ -91,6 +91,7 @@ If an empty list is used, all GPUs are disabled and no GPUs are used by the job.
 
         self.parser.add_argument('-j', '--jobs',
             dest = 'jobs',
+            metavar = 'JOBS',
             action = 'store',
             type = int,
             default = 2,
@@ -98,10 +99,11 @@ If an empty list is used, all GPUs are disabled and no GPUs are used by the job.
 
         self.parser.add_argument('-r', '--repeats',
             dest = 'repeats',
+            metavar = 'N',
             action = 'store',
             type = int,
             default = 3,
-            help = 'repeat each measurement N times [default: 3]')
+            help = 'repeat each measurement N times, or indefinitely if 0 is given [default: 3]')
 
         self.parser.add_argument('--wait',
             dest = 'wait',
@@ -132,15 +134,26 @@ If an empty list is used, all GPUs are disabled and no GPUs are used by the job.
             help = 'number of GPUs used in each cmsRun job [default: 1]')
 
         group = self.parser.add_mutually_exclusive_group()
-        group.add_argument('--run-io-benchmark',
-            dest = 'run_io_benchmark',
-            action= 'store_true',
-            default = True,
-            help = 'measure the I/O benchmarks before the other measurements [default: True]')
-        group.add_argument('--no-run-io-benchmark',
-            dest = 'run_io_benchmark',
+        group.add_argument('--input-benchmark', '--run-io-benchmark',
+            dest = 'input_benchmark',
+            metavar = 'N',
+            action= 'store',
+            type = int,
+            nargs = '?',
+            const = -1,
+            default = -1,
+            help = 'measure the input-only throughput N times before performing any other measurements [default: as many repetitions as given by --repeats]. The legacy option name "--run-io-benchmark N" is deprecated.')
+        group.add_argument('--no-input-benchmark', '--no-run-io-benchmark',
+            dest = 'input_benchmark',
             action= 'store_false',
-            help = 'skip the I/O measurement')
+            help = 'do not run the input-only throughput measurements (equivalent to "--input-benchmark 0"). The legacy option name "--no-run-io-benchmark" is deprecated.')
+        self.parser.add_argument('--input-collections',
+            dest = 'input_collections',
+            metavar = 'BRANCH[,BRANCH,...]',
+            action = 'store',
+            type = str,
+            default = 'rawDataCollector',
+            help = 'comma-separated list of input collections to read for the input-only throughput measurements [default: rawDataCollector]')
 
         group = self.parser.add_mutually_exclusive_group()
         group.add_argument('-R', '--reference-benchmark',
@@ -328,6 +341,10 @@ If an empty list is used, all GPUs are disabled and no GPUs are used by the job.
           except:
             print("The yappi package is not present, CPU usage profiling will be disabled.")
             options.debug_cpu_usage = False
+
+        # adjust the number of repetitions for the input-only benchmark
+        if options.input_benchmark == -1:
+            options.input_benchmark = options.repeats if options.repeats != 0 else 3
 
         return options
 

--- a/options.py
+++ b/options.py
@@ -147,13 +147,21 @@ If an empty list is used, all GPUs are disabled and no GPUs are used by the job.
             dest = 'input_benchmark',
             action= 'store_false',
             help = 'do not run the input-only throughput measurements (equivalent to "--input-benchmark 0"). The legacy option name "--no-run-io-benchmark" is deprecated.')
-        self.parser.add_argument('--input-collections',
+        group = self.parser.add_mutually_exclusive_group()
+        group.add_argument('--input-collections',
             dest = 'input_collections',
             metavar = 'BRANCH[,BRANCH,...]',
             action = 'store',
             type = str,
             default = 'rawDataCollector',
             help = 'comma-separated list of input collections to read for the input-only throughput measurements [default: rawDataCollector]')
+        group.add_argument('--input-xml',
+            dest = 'input_xml',
+            metavar = 'FILE',
+            action = 'store',
+            type = str,
+            default = None,
+            help = 'read the list of input collections to read for the input-only throughput measurements from a framework job report XML file.')
 
         group = self.parser.add_mutually_exclusive_group()
         group.add_argument('-R', '--reference-benchmark',

--- a/scan
+++ b/scan
@@ -139,11 +139,13 @@ if __name__ == "__main__":
   if not opts.steps:
     steps = list(range(opts.min_step, max_step + 1))
 
-  # prepare a trimmed down configuration for benchmarking only reading the input data
-  if opts.run_io_benchmark:
+  if opts.input_benchmark:
+    # prepare a trimmed down configuration for benchmarking only reading the input data
     io_process = copy.deepcopy(process)
-    io_process.hltGetRaw = cms.EDAnalyzer("HLTGetRaw", RawDataCollection = cms.InputTag("rawDataCollector"))
-    io_process.path = cms.Path(io_process.hltGetRaw)
+    io_process.prefetch = cms.EDAnalyzer("GenericConsumer",
+        eventProducts = cms.untracked.vstring(opts.input_collections.split(','))
+    )
+    io_process.path = cms.Path(io_process.prefetch)
     io_process.schedule = cms.Schedule(io_process.path)
     if 'PrescaleService' in io_process.__dict__:
       del io_process.PrescaleService
@@ -182,9 +184,9 @@ if __name__ == "__main__":
       printCommonArgs(step_opt)
       
     # benchmark reading the input data
-    if opts.run_io_benchmark:
-      print('Benchmarking only I/O')
-      io_options = dict(step_opt, logdir = None, keep = [], data = None)
+    if opts.input_benchmark:
+      print('Benchmarking only the input')
+      io_options = dict(step_opt, repeats = opts.input_benchmark, logdir = None, keep = [], data = None)
       multiCmsRun(io_process, **io_options)
       print()
       # schedule a wait after the I/O benchmark

--- a/test/report.xml
+++ b/test/report.xml
@@ -1,0 +1,170 @@
+<FrameworkJobReport>
+
+<Process>
+  <Name>HLTX</Name>
+  <ReducedConfigurationID>1cedf521d3e1adb04f8ad0ae76722b33</ReducedConfigurationID>
+  <ParameterSetID>f7dcdcbf1dc4ad0c47c611449b2459aa</ParameterSetID>
+</Process>
+
+<InputFile>
+<State  Value="closed"/>
+<LFN></LFN>
+<PFN>file:/cms-hlt-nfs/user/fwyzard/ngt32/CMSSW_16_0_1/run/af58311d-b9a8-4613-9b3f-2e7eaf50ee3c.root</PFN>
+<Catalog></Catalog>
+<ModuleLabel>source</ModuleLabel>
+<GUID>af58311d-b9a8-4613-9b3f-2e7eaf50ee3c</GUID>
+<Branches>
+  <Branch>FEDRawDataCollection_rawDataCollector__LHC.</Branch>
+  <Branch>GlobalObjectMapRecord_hltGtStage2ObjectMap__HLT.</Branch>
+  <Branch>edmTriggerResults_TriggerResults__HLT.</Branch>
+  <Branch>triggerTriggerEvent_hltTriggerSummaryAOD__HLT.</Branch>
+</Branches>
+<InputType>primaryFiles</InputType>
+<InputSourceClass>PoolSource</InputSourceClass>
+<EventsRead>2926</EventsRead>
+<Runs>
+<Run ID="398183">
+   <LumiSection ID="324"/>
+   <LumiSection ID="325"/>
+</Run>
+
+</Runs>
+</InputFile>
+<PerformanceReport>
+  <PerformanceSummary Metric="StorageStatistics">
+    <Metric Name="Parameter-untracked-bool-enabled" Value="true"/>
+    <Metric Name="Parameter-untracked-bool-prefetching" Value="false"/>
+    <Metric Name="Parameter-untracked-bool-stats" Value="true"/>
+    <Metric Name="Parameter-untracked-string-cacheHint" Value="auto-detect"/>
+    <Metric Name="Parameter-untracked-string-readHint" Value="auto-detect"/>
+    <Metric Name="ROOT-tfile-read-totalMegabytes" Value="3894.16"/>
+    <Metric Name="ROOT-tfile-write-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-close-maxMsecs" Value="0.536929"/>
+    <Metric Name="Timing-file-close-minMsecs" Value="0.536929"/>
+    <Metric Name="Timing-file-close-numOperations" Value="1"/>
+    <Metric Name="Timing-file-close-numSuccessfulOperations" Value="1"/>
+    <Metric Name="Timing-file-close-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-close-totalMsecs" Value="0.536929"/>
+    <Metric Name="Timing-file-construct-maxMsecs" Value="8e-05"/>
+    <Metric Name="Timing-file-construct-minMsecs" Value="8e-05"/>
+    <Metric Name="Timing-file-construct-numOperations" Value="1"/>
+    <Metric Name="Timing-file-construct-numSuccessfulOperations" Value="1"/>
+    <Metric Name="Timing-file-construct-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-construct-totalMsecs" Value="8e-05"/>
+    <Metric Name="Timing-file-destruct-maxMsecs" Value="0.00454"/>
+    <Metric Name="Timing-file-destruct-minMsecs" Value="0.00454"/>
+    <Metric Name="Timing-file-destruct-numOperations" Value="1"/>
+    <Metric Name="Timing-file-destruct-numSuccessfulOperations" Value="1"/>
+    <Metric Name="Timing-file-destruct-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-destruct-totalMsecs" Value="0.00454"/>
+    <Metric Name="Timing-file-open-maxMsecs" Value="1.35212"/>
+    <Metric Name="Timing-file-open-minMsecs" Value="1.35212"/>
+    <Metric Name="Timing-file-open-numOperations" Value="1"/>
+    <Metric Name="Timing-file-open-numSuccessfulOperations" Value="1"/>
+    <Metric Name="Timing-file-open-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-open-totalMsecs" Value="1.35212"/>
+    <Metric Name="Timing-file-position-maxMsecs" Value="0.007841"/>
+    <Metric Name="Timing-file-position-minMsecs" Value="0.00029"/>
+    <Metric Name="Timing-file-position-numOperations" Value="4661"/>
+    <Metric Name="Timing-file-position-numSuccessfulOperations" Value="4661"/>
+    <Metric Name="Timing-file-position-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-position-totalMsecs" Value="4.70736"/>
+    <Metric Name="Timing-file-prefetch-maxMsecs" Value="0.285785"/>
+    <Metric Name="Timing-file-prefetch-minMsecs" Value="4e-05"/>
+    <Metric Name="Timing-file-prefetch-numOperations" Value="26376"/>
+    <Metric Name="Timing-file-prefetch-numSuccessfulOperations" Value="26376"/>
+    <Metric Name="Timing-file-prefetch-totalMegabytes" Value="123.447"/>
+    <Metric Name="Timing-file-prefetch-totalMsecs" Value="21.8116"/>
+    <Metric Name="Timing-file-read-maxMsecs" Value="2.61905"/>
+    <Metric Name="Timing-file-read-minMsecs" Value="0.00086"/>
+    <Metric Name="Timing-file-read-numOperations" Value="2334"/>
+    <Metric Name="Timing-file-read-numSuccessfulOperations" Value="2334"/>
+    <Metric Name="Timing-file-read-totalMegabytes" Value="3892.68"/>
+    <Metric Name="Timing-file-read-totalMsecs" Value="746.286"/>
+    <Metric Name="Timing-file-readv-maxMsecs" Value="0"/>
+    <Metric Name="Timing-file-readv-minMsecs" Value="0"/>
+    <Metric Name="Timing-file-readv-numOperations" Value="0"/>
+    <Metric Name="Timing-file-readv-numSuccessfulOperations" Value="0"/>
+    <Metric Name="Timing-file-readv-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-readv-totalMsecs" Value="0"/>
+    <Metric Name="Timing-file-stagein-maxMsecs" Value="0.00178"/>
+    <Metric Name="Timing-file-stagein-minMsecs" Value="0.00178"/>
+    <Metric Name="Timing-file-stagein-numOperations" Value="1"/>
+    <Metric Name="Timing-file-stagein-numSuccessfulOperations" Value="1"/>
+    <Metric Name="Timing-file-stagein-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-stagein-totalMsecs" Value="0.00178"/>
+    <Metric Name="Timing-file-write-maxMsecs" Value="0"/>
+    <Metric Name="Timing-file-write-minMsecs" Value="0"/>
+    <Metric Name="Timing-file-write-numOperations" Value="0"/>
+    <Metric Name="Timing-file-write-numSuccessfulOperations" Value="0"/>
+    <Metric Name="Timing-file-write-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-write-totalMsecs" Value="0"/>
+    <Metric Name="Timing-file-writev-maxMsecs" Value="0"/>
+    <Metric Name="Timing-file-writev-minMsecs" Value="0"/>
+    <Metric Name="Timing-file-writev-numOperations" Value="0"/>
+    <Metric Name="Timing-file-writev-numSuccessfulOperations" Value="0"/>
+    <Metric Name="Timing-file-writev-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-file-writev-totalMsecs" Value="0"/>
+    <Metric Name="Timing-tstoragefile-close-maxMsecs" Value="0.546669"/>
+    <Metric Name="Timing-tstoragefile-close-minMsecs" Value="0.546669"/>
+    <Metric Name="Timing-tstoragefile-close-numOperations" Value="1"/>
+    <Metric Name="Timing-tstoragefile-close-numSuccessfulOperations" Value="1"/>
+    <Metric Name="Timing-tstoragefile-close-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-tstoragefile-close-totalMsecs" Value="0.546669"/>
+    <Metric Name="Timing-tstoragefile-construct-maxMsecs" Value="252.192"/>
+    <Metric Name="Timing-tstoragefile-construct-minMsecs" Value="252.192"/>
+    <Metric Name="Timing-tstoragefile-construct-numOperations" Value="1"/>
+    <Metric Name="Timing-tstoragefile-construct-numSuccessfulOperations" Value="1"/>
+    <Metric Name="Timing-tstoragefile-construct-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-tstoragefile-construct-totalMsecs" Value="252.192"/>
+    <Metric Name="Timing-tstoragefile-read-maxMsecs" Value="2.62095"/>
+    <Metric Name="Timing-tstoragefile-read-minMsecs" Value="0.001681"/>
+    <Metric Name="Timing-tstoragefile-read-numOperations" Value="2334"/>
+    <Metric Name="Timing-tstoragefile-read-numSuccessfulOperations" Value="2334"/>
+    <Metric Name="Timing-tstoragefile-read-totalMegabytes" Value="3892.68"/>
+    <Metric Name="Timing-tstoragefile-read-totalMsecs" Value="750.132"/>
+    <Metric Name="Timing-tstoragefile-readActual-maxMsecs" Value="2.61985"/>
+    <Metric Name="Timing-tstoragefile-readActual-minMsecs" Value="0.00095"/>
+    <Metric Name="Timing-tstoragefile-readActual-numOperations" Value="2334"/>
+    <Metric Name="Timing-tstoragefile-readActual-numSuccessfulOperations" Value="2334"/>
+    <Metric Name="Timing-tstoragefile-readActual-totalMegabytes" Value="3892.68"/>
+    <Metric Name="Timing-tstoragefile-readActual-totalMsecs" Value="747.125"/>
+    <Metric Name="Timing-tstoragefile-readAsync-maxMsecs" Value="0.286005"/>
+    <Metric Name="Timing-tstoragefile-readAsync-minMsecs" Value="0.00013"/>
+    <Metric Name="Timing-tstoragefile-readAsync-numOperations" Value="26376"/>
+    <Metric Name="Timing-tstoragefile-readAsync-numSuccessfulOperations" Value="26376"/>
+    <Metric Name="Timing-tstoragefile-readAsync-totalMegabytes" Value="20.4709"/>
+    <Metric Name="Timing-tstoragefile-readAsync-totalMsecs" Value="36.4184"/>
+    <Metric Name="Timing-tstoragefile-readPrefetchToCache-maxMsecs" Value="0.003"/>
+    <Metric Name="Timing-tstoragefile-readPrefetchToCache-minMsecs" Value="5e-05"/>
+    <Metric Name="Timing-tstoragefile-readPrefetchToCache-numOperations" Value="2315"/>
+    <Metric Name="Timing-tstoragefile-readPrefetchToCache-numSuccessfulOperations" Value="728"/>
+    <Metric Name="Timing-tstoragefile-readPrefetchToCache-totalMegabytes" Value="1.51103"/>
+    <Metric Name="Timing-tstoragefile-readPrefetchToCache-totalMsecs" Value="0.119832"/>
+    <Metric Name="Timing-tstoragefile-seek-maxMsecs" Value="0.01354"/>
+    <Metric Name="Timing-tstoragefile-seek-minMsecs" Value="0.00039"/>
+    <Metric Name="Timing-tstoragefile-seek-numOperations" Value="4649"/>
+    <Metric Name="Timing-tstoragefile-seek-numSuccessfulOperations" Value="4649"/>
+    <Metric Name="Timing-tstoragefile-seek-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-tstoragefile-seek-totalMsecs" Value="6.0308"/>
+    <Metric Name="Timing-tstoragefile-stat-maxMsecs" Value="0.007081"/>
+    <Metric Name="Timing-tstoragefile-stat-minMsecs" Value="0.00396"/>
+    <Metric Name="Timing-tstoragefile-stat-numOperations" Value="2"/>
+    <Metric Name="Timing-tstoragefile-stat-numSuccessfulOperations" Value="2"/>
+    <Metric Name="Timing-tstoragefile-stat-totalMegabytes" Value="0"/>
+    <Metric Name="Timing-tstoragefile-stat-totalMsecs" Value="0.011041"/>
+  </PerformanceSummary>
+</PerformanceReport>
+<PerformanceReport>
+  <PerformanceSummary Metric="SystemCPU">
+    <Metric Name="CPUModels" Value="AMD EPYC 9534 64-Core Processor"/>
+    <Metric Name="averageCoreSpeed" Value="1826.605793"/>
+    <Metric Name="cpusetCount" Value="62"/>
+    <Metric Name="totalCPUs" Value="256"/>
+  </PerformanceSummary>
+</PerformanceReport>
+<ReadBranches>
+<Branch Name="FEDRawDataCollection_rawDataCollector__LHC." ReadCount="2926"/>
+</ReadBranches>
+<!--                                                            -->
+</FrameworkJobReport>


### PR DESCRIPTION
Replace the options `--run-io-benchmark` / `--no-run-io-benchmark` with `--input-benchmark [N]` / `--no-input-benchmark`.
The new option takes an optional argument to specify the number of repetitions used for the input-only benchmark, while the default value remains the same as the number of repetitions for the main benchmark.

Add a new option `--input-collections BRANCH[,BRANCH,...]` to specify the list of collections (or input branches) to be read during the input-only benchmark. By default read only the "rawDataCollector" FED raw data collection.

Update the configuration of the input-only benchmark and replace the `HLTGetRaw` module with the `GenericConsumer` module, that can consume an arbitrary list of input collections.